### PR TITLE
Navbar fix for Recipe & Map page. + Transparent Box

### DIFF
--- a/advice.html
+++ b/advice.html
@@ -184,10 +184,24 @@
 
 <!-- Footer of the page -->
 <footer>
+
+  <style>
+    div.adviceBox {
+      margin-left:200px;
+      width:500px;
+      background-color:#ffffff;
+      opacity:0.6;
+      filter: alpha(opacity=60);
+      font-weight:bold;
+    }
+  </style>
+
   <div class="container fixed-bottom" id="footer">
+    <div class="adviceBox">
     <!-- Reference to source -->
-    <p>All Contents of this page comes from <a href="http://thelittlegreenblogger.com/index.php/2019/09/07/10-tips-for-sustainable-living/" class="text-success stretched-link">thelittlegreenblogger.com</a>
+    <p>All contents of this page comes from <a href="http://thelittlegreenblogger.com/index.php/2019/09/07/10-tips-for-sustainable-living/" class="text-success stretched-link">thelittlegreenblogger.com</a>
     </p>
+    </div>
   </div>
 </footer>
 

--- a/map.html
+++ b/map.html
@@ -19,10 +19,10 @@
 
     <!-- Code for the side navigation bar, link each nav item to their corresponding page -->
     <div class="sidenav">
-      <a href="index.html">Home</a>
-      <a href="map.html">Map</a>
-      <a href="recipe.html">Recipe</a>
-      <a href="advice.html">Advice</a>
+      <a href="index.html" id="navitem">Home</a>
+      <a class="nav-link" id="navitem" href="map.html">Map</a>
+       <a class="nav-link" id="navitem" href="recipe.html">Recipe</a>
+       <a class="nav-link" id="navitem"  href="advice.html">Advice</a>
     </div>
 
   <!-- Code for the header of the page -->

--- a/recipe.html
+++ b/recipe.html
@@ -17,10 +17,10 @@
 
   <!-- Code for the side navigation bar, link each nav item to their corresponding page -->
   <div class="sidenav">
-    <a href="index.html">Home</a>
-    <a href="map.html">Map</a>
-    <a href="recipe.html">Recipe</a>
-    <a href="advice.html">Advice</a>
+    <a href="index.html" id="navitem">Home</a>
+    <a class="nav-link" id="navitem" href="map.html">Map</a>
+     <a class="nav-link" id="navitem" href="recipe.html">Recipe</a>
+     <a class="nav-link" id="navitem"  href="advice.html">Advice</a>
   </div>
 
   <!-- Code for the header of the page -->
@@ -306,8 +306,22 @@
 </body>
 
 <footer>
+
+  <style>
+    div.recipeBox {
+      margin-left:200px;
+      width:500px;
+      background-color:#ffffff;
+      opacity:0.6;
+      filter: alpha(opacity=60);
+      font-weight:bold;
+    }
+  </style>
+
   <div class="container fixed-bottom" id="footer">
+    <div class="recipeBox">
     <p>All recipe's were provided to us by the owner of The Little Green Larder.</p>
+    </div>
   </div>
 </footer>
 


### PR DESCRIPTION
The Navbar for the Recipe and Map page have been fixed (they didn't have the id="navitem" so there was no CSS applied to them like the other pages). 

A transparent box has been added (using <style>) to the Recipe and Advice page so the text is easier on the eyes in front of the rest of the page's contents. 